### PR TITLE
#10 Update VM Size into Standard_B2s_v2

### DIFF
--- a/infrastructure/deploy/k8s/create-aks.sh
+++ b/infrastructure/deploy/k8s/create-aks.sh
@@ -112,7 +112,7 @@ fi
 # AKS Cluster creation
 echo
 echo "Creating AKS cluster \"$clusterAksName\" in resource group \"$clusterRg\" and location \"$clusterLocation\"..."
-aksCreateCommand="az aks create -n $clusterAksName -g $clusterRg --node-count $clusterNodeCount --node-vm-size Standard_B2s --vm-set-type VirtualMachineScaleSets -l $clusterLocation --enable-managed-identity --generate-ssh-keys -o json"
+aksCreateCommand="az aks create -n $clusterAksName -g $clusterRg --node-count $clusterNodeCount --node-vm-size Standard_B2s_v2 --vm-set-type VirtualMachineScaleSets -l $clusterLocation --enable-managed-identity --generate-ssh-keys -o json"
 echo "${newline} > ${azCliCommandStyle}$aksCreateCommand${defaultTextStyle}${newline}"
 retry=5
 aks=`$aksCreateCommand`


### PR DESCRIPTION
When I run the deployment script, it seems the available VM size name is changed from "Standard_B2S" into "standard_b2s_v2". So the setup script cannot create the AKS.